### PR TITLE
Update to non-yanked mimemagic version

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '>= 1.6.6'
   s.add_runtime_dependency 'rubyzip', '>= 1.2.1'
   s.add_runtime_dependency "htmlentities", "~> 4.3.4"
-  s.add_runtime_dependency "mimemagic", "~> 0.3"
+  s.add_runtime_dependency "mimemagic", "0.3.6"
 
   s.add_development_dependency 'yard'
   s.add_development_dependency 'kramdown'


### PR DESCRIPTION
All other `0.3.x` versions have been yanked.